### PR TITLE
Build out REST endpoints for Bucketlists and Bucketlist resources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ env
 *.pyc
 __pycache__
 db.sqlite3
+*.coverage

--- a/app/settings.py
+++ b/app/settings.py
@@ -140,11 +140,6 @@ STATIC_URL = '/static/'
 
 AUTH_USER_MODEL = 'bucketlist.Account'
 
-# # pagination class
-# REST_FRAMEWORK = {
-#     'PAGE_SIZE': 5
-# }
-
 REST_FRAMEWORK = {
     # Use Django's standard `django.contrib.auth` permissions,
     # or allow read-only access for unauthenticated users.
@@ -156,12 +151,9 @@ REST_FRAMEWORK = {
         'rest_framework.authentication.TokenAuthentication',
         'rest_framework.authentication.SessionAuthentication',
     ),
-    # 'DEFAULT_RENDERER_CLASSES': (
-    #     'rest_framework.renderers.JSONRenderer',
-    # ),
-    # 'DEFAULT_PAGINATION_CLASS':
-    # 'rest_framework.pagination.PageNumberPagination',
-    # 'PAGE_SIZE': 5
+    'DEFAULT_PAGINATION_CLASS':
+    'rest_framework.pagination.PageNumberPagination',
+    'PAGE_SIZE': 5
 }
 
 

--- a/app/settings.py
+++ b/app/settings.py
@@ -11,6 +11,7 @@ https://docs.djangoproject.com/en/1.9/ref/settings/
 """
 
 import os
+import sys
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -88,6 +89,10 @@ DATABASES = {
     }
 }
 
+# Alter database to Cover regular testing and django-coverage
+if 'test' in sys.argv or 'test_coverage' in sys.argv:
+    DATABASES['default']['ENGINE'] = 'django.db.backends.sqlite3'
+
 
 # Password validation
 # https://docs.djangoproject.com/en/1.9/ref/settings/#auth-password-validators
@@ -138,8 +143,8 @@ REST_FRAMEWORK = {
 }
 
 # REST_FRAMEWORK = {
-#     # Use Django's standard `django.contrib.auth` permissions,
-#     # or allow read-only access for unauthenticated users.
+# Use Django's standard `django.contrib.auth` permissions,
+# or allow read-only access for unauthenticated users.
 #     'DEFAULT_PERMISSION_CLASSES': [
 #         'rest_framework.permissions.DjangoModelPermissionsOrAnonReadOnly'
 #     ],
@@ -150,9 +155,9 @@ REST_FRAMEWORK = {
 #     'DEFAULT_RENDERER_CLASSES': (
 #         'rest_framework.renderers.JSONRenderer',
 #     ),
-#     # 'DEFAULT_PAGINATION_CLASS':
-#     #     'rest_framework.pagination.PageNumberPagination',
-#     # 'PAGE_SIZE': 3
+# 'DEFAULT_PAGINATION_CLASS':
+# 'rest_framework.pagination.PageNumberPagination',
+# 'PAGE_SIZE': 3
 # }
 
 

--- a/app/settings.py
+++ b/app/settings.py
@@ -38,9 +38,12 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
-    'bucketlist',
+    # third-party apps
     'rest_framework',
     'rest_framework_swagger',
+    'rest_framework.authtoken',
+    # internal apps
+    'bucketlist',
 ]
 
 MIDDLEWARE_CLASSES = [
@@ -137,28 +140,29 @@ STATIC_URL = '/static/'
 
 AUTH_USER_MODEL = 'bucketlist.Account'
 
-# pagination class
-REST_FRAMEWORK = {
-    'PAGE_SIZE': 5
-}
-
+# # pagination class
 # REST_FRAMEWORK = {
-# Use Django's standard `django.contrib.auth` permissions,
-# or allow read-only access for unauthenticated users.
-#     'DEFAULT_PERMISSION_CLASSES': [
-#         'rest_framework.permissions.DjangoModelPermissionsOrAnonReadOnly'
-#     ],
-#     'DEFAULT_AUTHENTICATION_CLASSES': (
-#         'rest_framework.authentication.TokenAuthentication',
-#         'rest_framework.authentication.SessionAuthentication',
-#     ),
-#     'DEFAULT_RENDERER_CLASSES': (
-#         'rest_framework.renderers.JSONRenderer',
-#     ),
-# 'DEFAULT_PAGINATION_CLASS':
-# 'rest_framework.pagination.PageNumberPagination',
-# 'PAGE_SIZE': 3
+#     'PAGE_SIZE': 5
 # }
+
+REST_FRAMEWORK = {
+    # Use Django's standard `django.contrib.auth` permissions,
+    # or allow read-only access for unauthenticated users.
+    'DEFAULT_PERMISSION_CLASSES': [
+        # 'rest_framework.permissions.DjangoModelPermissionsOrAnonReadOnly',
+        'rest_framework.permissions.IsAuthenticated'
+    ],
+    'DEFAULT_AUTHENTICATION_CLASSES': (
+        'rest_framework.authentication.TokenAuthentication',
+        'rest_framework.authentication.SessionAuthentication',
+    ),
+    # 'DEFAULT_RENDERER_CLASSES': (
+    #     'rest_framework.renderers.JSONRenderer',
+    # ),
+    # 'DEFAULT_PAGINATION_CLASS':
+    # 'rest_framework.pagination.PageNumberPagination',
+    # 'PAGE_SIZE': 5
+}
 
 
 SWAGGER_SETTINGS = {
@@ -167,3 +171,5 @@ SWAGGER_SETTINGS = {
     'is_superuser': True,
     'permission_denied_handler': 'django.contrib.auth.views.login',
 }
+
+TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'

--- a/app/settings.py
+++ b/app/settings.py
@@ -132,10 +132,10 @@ STATIC_URL = '/static/'
 
 AUTH_USER_MODEL = 'bucketlist.Account'
 
-# # pagination class
-# REST_FRAMEWORK = {
-#     'PAGE_SIZE': 3
-# }
+# pagination class
+REST_FRAMEWORK = {
+    'PAGE_SIZE': 5
+}
 
 # REST_FRAMEWORK = {
 #     # Use Django's standard `django.contrib.auth` permissions,

--- a/app/settings.py
+++ b/app/settings.py
@@ -39,6 +39,7 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
     'bucketlist',
     'rest_framework',
+    'rest_framework_swagger',
 ]
 
 MIDDLEWARE_CLASSES = [
@@ -131,7 +132,33 @@ STATIC_URL = '/static/'
 
 AUTH_USER_MODEL = 'bucketlist.Account'
 
-# pagination class
-REST_FRAMEWORK = {
-    'PAGE_SIZE': 10
+# # pagination class
+# REST_FRAMEWORK = {
+#     'PAGE_SIZE': 3
+# }
+
+# REST_FRAMEWORK = {
+#     # Use Django's standard `django.contrib.auth` permissions,
+#     # or allow read-only access for unauthenticated users.
+#     'DEFAULT_PERMISSION_CLASSES': [
+#         'rest_framework.permissions.DjangoModelPermissionsOrAnonReadOnly'
+#     ],
+#     'DEFAULT_AUTHENTICATION_CLASSES': (
+#         'rest_framework.authentication.TokenAuthentication',
+#         'rest_framework.authentication.SessionAuthentication',
+#     ),
+#     'DEFAULT_RENDERER_CLASSES': (
+#         'rest_framework.renderers.JSONRenderer',
+#     ),
+#     # 'DEFAULT_PAGINATION_CLASS':
+#     #     'rest_framework.pagination.PageNumberPagination',
+#     # 'PAGE_SIZE': 3
+# }
+
+
+SWAGGER_SETTINGS = {
+    'api_path': '/',
+    'is_authenticated': True,
+    'is_superuser': True,
+    'permission_denied_handler': 'django.contrib.auth.views.login',
 }

--- a/app/urls.py
+++ b/app/urls.py
@@ -24,5 +24,5 @@ urlpatterns = [
     url(r'^api/auth/',
         include('rest_framework.urls', namespace='rest_framework')),
     url(r'^docs/', include('rest_framework_swagger.urls')),
-    url(r'^api/token/', views.obtain_auth_token),
+    url(r'^api/token/', views.obtain_auth_token, name='token'),
 ]

--- a/app/urls.py
+++ b/app/urls.py
@@ -20,7 +20,7 @@ from rest_framework.authtoken import views
 
 urlpatterns = [
     url(r'^admin/', admin.site.urls),
-    url(r'^api/', include('bucketlist.urls'), name='bucketlist'),
+    url(r'^api/v1/', include('bucketlist.urls'), name='bucketlist'),
     url(r'^api/auth/',
         include('rest_framework.urls', namespace='rest_framework')),
     url(r'^docs/', include('rest_framework_swagger.urls')),

--- a/app/urls.py
+++ b/app/urls.py
@@ -30,4 +30,5 @@ urlpatterns = [
     url(r'^', include('bucketlist.urls')),
     url(r'^api/auth/',
         include('rest_framework.urls', namespace='rest_framework')),
+    url(r'^docs/', include('rest_framework_swagger.urls'))
 ]

--- a/app/urls.py
+++ b/app/urls.py
@@ -17,20 +17,12 @@ from django.conf.urls import url, include
 from django.contrib import admin
 
 from rest_framework.authtoken import views
-from rest_framework_nested import routers
-# from bucketlist.views import AccountViewSet
-from app.views import IndexView
-
-router = routers.SimpleRouter()
-# router.register(r'accounts', AccountViewSet)
 
 urlpatterns = [
     url(r'^admin/', admin.site.urls),
-    url(r'^api/v1/', include(router.urls)),
-    # url(r'^.*$', IndexView.as_view(), name='index'),
-    url(r'^', include('bucketlist.urls'), name='bucketlist'),
+    url(r'^api/', include('bucketlist.urls'), name='bucketlist'),
     url(r'^api/auth/',
         include('rest_framework.urls', namespace='rest_framework')),
     url(r'^docs/', include('rest_framework_swagger.urls')),
-    url(r'^api-token-auth/', views.obtain_auth_token),
+    url(r'^api/token/', views.obtain_auth_token),
 ]

--- a/app/urls.py
+++ b/app/urls.py
@@ -16,9 +16,10 @@ Including another URLconf
 from django.conf.urls import url, include
 from django.contrib import admin
 
+from rest_framework.authtoken import views
 from rest_framework_nested import routers
 # from bucketlist.views import AccountViewSet
-# from app.views import IndexView
+from app.views import IndexView
 
 router = routers.SimpleRouter()
 # router.register(r'accounts', AccountViewSet)
@@ -27,8 +28,9 @@ urlpatterns = [
     url(r'^admin/', admin.site.urls),
     url(r'^api/v1/', include(router.urls)),
     # url(r'^.*$', IndexView.as_view(), name='index'),
-    url(r'^', include('bucketlist.urls')),
+    url(r'^', include('bucketlist.urls'), name='bucketlist'),
     url(r'^api/auth/',
         include('rest_framework.urls', namespace='rest_framework')),
-    url(r'^docs/', include('rest_framework_swagger.urls'))
+    url(r'^docs/', include('rest_framework_swagger.urls')),
+    url(r'^api-token-auth/', views.obtain_auth_token),
 ]

--- a/bucketlist/fixtures/bucketlist.json
+++ b/bucketlist/fixtures/bucketlist.json
@@ -1,0 +1,90 @@
+[
+    {
+        "fields":{
+            "username": "joan",
+            "password": "pbkdf2_sha256$24000$8yQg8hgMUsl4$w5dQFJ7maV9QcuCdAmgCo5gaKfScL7CSmPuvhRJ53a4=",
+            "is_active": true,
+            "is_superuser": true,
+            "is_staff": true,
+            "tagline": "Just Do It",
+            "created_at": "2016-03-10 22:33:17.697483+03" ,
+            "updated_at": "2016-03-10 22:33:17.697483+03"
+            },
+        "model": "bucketlist.Account",
+        "pk": 1
+    },
+    {
+        "fields":{
+            "name": "Twende Nyumbani",
+            "creator": 1,
+            "created_at": "2016-03-17T08:01:50.039089Z",
+            "updated_at": "2016-03-17T08:01:50.039118Z"
+            },
+        "model": "bucketlist.Bucketlist",
+        "pk": 1
+    },
+    {
+        "fields":{
+            "name": "Temperature",
+            "creator": 1,
+            "created_at": "2016-03-17T08:01:50.039089Z",
+            "updated_at": "2016-03-17T08:01:50.039118Z"
+            },
+        "model": "bucketlist.Bucketlist",
+        "pk": 2
+    },
+    {
+        "fields":{
+            "name": "Buillon Van",
+            "creator": 1,
+            "created_at": "2016-03-17T08:01:50.039089Z",
+            "updated_at": "2016-03-17T08:01:50.039118Z"
+            },
+        "model": "bucketlist.Bucketlist",
+        "pk": 3
+    },
+    {
+        "fields":{
+            "name": "kansoul",
+            "done": false,
+            "bucketlist": 1,
+            "created_at": "2016-03-17T08:03:00.660591Z",
+            "updated_at": "2016-03-17T08:03:00.660614Z"
+            },
+        "model": "bucketlist.Bucketlistitem",
+        "pk": 1
+    },
+    {
+        "fields":{
+            "name": "yemi alade",
+            "done": false,
+            "bucketlist": 2,
+            "created_at": "2016-03-17T08:03:00.660591Z",
+            "updated_at": "2016-03-17T08:03:00.660614Z"
+            },
+        "model": "bucketlist.Bucketlistitem",
+        "pk": 2
+    },
+    {
+        "fields":{
+            "name": "Sauti Sol",
+            "done": false,
+            "bucketlist": 2,
+            "created_at": "2016-03-17T08:03:00.660591Z",
+            "updated_at": "2016-03-17T08:03:00.660614Z"
+            },
+        "model": "bucketlist.Bucketlistitem",
+        "pk": 3
+    },
+    {
+        "fields":{
+            "name": "MI and Avril",
+            "done": false,
+            "bucketlist": 3,
+            "created_at": "2016-03-17T08:03:00.660591Z",
+            "updated_at": "2016-03-17T08:03:00.660614Z"
+            },
+        "model": "bucketlist.Bucketlistitem",
+        "pk": 4
+    }
+]

--- a/bucketlist/models.py
+++ b/bucketlist/models.py
@@ -2,17 +2,6 @@ from __future__ import unicode_literals
 
 from django.db import models
 from django.contrib.auth.models import AbstractUser
-from django.db.models.signals import post_save
-from django.dispatch import receiver
-from rest_framework.authtoken.models import Token
-from django.conf import settings
-
-
-@receiver(post_save, sender=settings.AUTH_USER_MODEL)
-def create_auth_token(sender, instance=None, created=False, **kwargs):
-    """Create a token anytime a new Account is created"""
-    if created:
-        Token.objects.create(user=instance)
 
 
 class Account(AbstractUser):

--- a/bucketlist/models.py
+++ b/bucketlist/models.py
@@ -2,6 +2,17 @@ from __future__ import unicode_literals
 
 from django.db import models
 from django.contrib.auth.models import AbstractUser
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+from rest_framework.authtoken.models import Token
+from django.conf import settings
+
+
+@receiver(post_save, sender=settings.AUTH_USER_MODEL)
+def create_auth_token(sender, instance=None, created=False, **kwargs):
+    """Create a token anytime a new Account is created"""
+    if created:
+        Token.objects.create(user=instance)
 
 
 class Account(AbstractUser):

--- a/bucketlist/tests.py
+++ b/bucketlist/tests.py
@@ -1,3 +1,3 @@
 from django.test import TestCase
 
-# Create your tests here.
+from rest_framework.test import APITestCase

--- a/bucketlist/tests/test_api.py
+++ b/bucketlist/tests/test_api.py
@@ -1,0 +1,65 @@
+from rest_framework.test import APITestCase
+from django.core.urlresolvers import reverse
+
+from bucketlist.models import Account, Bucketlist, Bucketlistitem
+
+message = {"detail":
+           "Authentication credentials were not provided."}
+auth = '/api/token/'
+url = '/api/v1/bucketlists/'
+url2 = '/api/v1/bucketlists/1/'
+url3 = '/api/v1/bucketlists/1/items/'
+url4 = '/api/v1/bucketlists/1/items/1/'
+not_found_msg = {"detail": "Not found."}
+
+
+class BucketListApiTest(APITestCase):
+    """Test all bucketlist resource endpoints."""
+
+    def setUp(self):
+        """Create base authentication details."""
+        self.username = 'mama'
+        self.passsword = 'ashley'
+        self.user = Account.objects.create_user(
+            username=self.username, password=self.passsword)
+        url = reverse('token')
+        data = {'username': self.username, 'password': self.passsword}
+        self.response = self.client.post(url, data)
+        self.token = self.response.data.get('token')
+
+    def test_bucketlist_retrieval(self):
+        """Test that bucketlists can be retrieved from the DB."""
+        # unsuccessful retrieval w/out authentication
+        response = self.client.get(url)
+        self.assertEqual(response.data, message)
+        self.assertEqual(response.status_code, 401)
+
+        # add authentication to client
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+
+        # successful retrieval
+        auth_response = self.client.get(url)
+        self.assertEqual(auth_response.status_code, 200)
+
+    def test_bucketlist_creation(self):
+        """Test that bucketlists can be added to the DB."""
+        new_bl = {'name': 'Go to Rio'}
+        # unsuccessful retrieval w/out authentication
+        response = self.client.post(url, new_bl)
+        self.assertEqual(response.data, message)
+        self.assertEqual(response.status_code, 401)
+
+    def test_bucketlist_edition(self):
+        """Test that existing bucketlists can be edited."""
+        edited_bl = {'name': 'Go to Rio'}
+        # unsuccessful retrieval w/out authentication
+        response = self.client.put(url, edited_bl)
+        self.assertEqual(response.data, message)
+        self.assertEqual(response.status_code, 401)
+
+    def test_bucketlist_deletion(self):
+        """Test that existing bucketlists can be deleted from the DB."""
+        # unsuccessful removal w/out authentication
+        response = self.client.delete(url2)
+        self.assertEqual(response.data, message)
+        self.assertEqual(response.status_code, 401)

--- a/bucketlist/tests/test_api.py
+++ b/bucketlist/tests/test_api.py
@@ -7,23 +7,24 @@ message = {"detail":
            "Authentication credentials were not provided."}
 auth = '/api/token/'
 url = '/api/v1/bucketlists/'
-url2 = '/api/v1/bucketlists/1/'
-url3 = '/api/v1/bucketlists/1/items/'
-url4 = '/api/v1/bucketlists/1/items/1/'
+url2 = '/api/v1/bucketlists/2/'
+url3 = '/api/v1/bucketlists/2/items/'
+url4 = '/api/v1/bucketlists/2/items/2/'
+url5 = '/api/v1/bucketlists/4/'
 not_found_msg = {"detail": "Not found."}
 
 
 class BucketListApiTest(APITestCase):
     """Test all bucketlist resource endpoints."""
 
+    # Include 1 user,3 bucketlists and 4 bucketlistitems for testing purposes
+    fixtures = ['bucketlist.json']
+
     def setUp(self):
         """Create base authentication details."""
-        self.username = 'mama'
-        self.passsword = 'ashley'
-        self.user = Account.objects.create_user(
-            username=self.username, password=self.passsword)
         url = reverse('token')
-        data = {'username': self.username, 'password': self.passsword}
+        data = {
+            'username': Account.objects.get().username, 'password': 'ASHLEY19'}
         self.response = self.client.post(url, data)
         self.token = self.response.data.get('token')
 
@@ -37,25 +38,55 @@ class BucketListApiTest(APITestCase):
         # add authentication to client
         self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
 
-        # successful retrieval
+        # successful retrieval of all bucketlists
         auth_response = self.client.get(url)
         self.assertEqual(auth_response.status_code, 200)
+        self.assertEqual(auth_response.data['count'], 3)
+
+        # successful retrieval of a single bucketlist
+        auth_response = self.client.get(url2)
+        self.assertEqual(auth_response.status_code, 200)
+        self.assertEqual(auth_response.data.get('name'), 'Temperature')
 
     def test_bucketlist_creation(self):
         """Test that bucketlists can be added to the DB."""
         new_bl = {'name': 'Go to Rio'}
+
         # unsuccessful retrieval w/out authentication
         response = self.client.post(url, new_bl)
         self.assertEqual(response.data, message)
         self.assertEqual(response.status_code, 401)
 
+        # add authentication to client
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+
+        # successful addition of a bucketlist
+        auth_response = self.client.post(url, new_bl)
+        self.assertEqual(auth_response.status_code, 201)
+        self.assertEqual(auth_response.data.get('name'), 'Go to Rio')
+        self.assertEqual(Bucketlist.objects.count(), 4)
+
     def test_bucketlist_edition(self):
         """Test that existing bucketlists can be edited."""
-        edited_bl = {'name': 'Go to Rio'}
+        edited_bl = {'name': 'Catch mafeelings'}
+
         # unsuccessful retrieval w/out authentication
-        response = self.client.put(url, edited_bl)
+        response = self.client.put(url2, edited_bl)
         self.assertEqual(response.data, message)
         self.assertEqual(response.status_code, 401)
+
+        # add authentication to client
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+
+        # successful edition of a bucketlist
+        auth_response = self.client.put(url2, edited_bl)
+        self.assertEqual(auth_response.status_code, 200)
+        self.assertEqual(auth_response.data.get('name'), 'Catch mafeelings')
+
+        # test that only bucketlilsts that exist can be updated
+        auth_response = self.client.put(url5, edited_bl)
+        self.assertEqual(auth_response.status_code, 404)
+        self.assertEqual(auth_response.data, not_found_msg)
 
     def test_bucketlist_deletion(self):
         """Test that existing bucketlists can be deleted from the DB."""
@@ -63,3 +94,61 @@ class BucketListApiTest(APITestCase):
         response = self.client.delete(url2)
         self.assertEqual(response.data, message)
         self.assertEqual(response.status_code, 401)
+
+        # add authentication to client
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+
+        # successfule deletion
+        auth_response = self.client.delete(url2)
+        self.assertEqual(auth_response.status_code, 204)
+        self.assertEqual(Bucketlist.objects.count(), 2)
+
+    def test_bucketlistitem_creation(self):
+        """Test that a bucketlistitem can be added to a bucketlist."""
+        new_item = {'name': 'Zigo Remix', 'bucketlist': 2}
+
+        # unsuccessful creation w/out authentication
+        response = self.client.post(url3, new_item)
+        self.assertEqual(response.data, message)
+        self.assertEqual(response.status_code, 401)
+
+        # add authentication to client
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+
+        # successful creation of a bucketlist item.
+        auth_response = self.client.post(url3, new_item)
+        self.assertEqual(auth_response.status_code, 201)
+        self.assertEqual(auth_response.data.get('name'), 'Zigo Remix')
+        self.assertEqual(Bucketlistitem.objects.count(), 5)
+
+    def test_bucketlistitem_edition(self):
+        """Test that a bucketlistitem can be updated."""
+        edited_item = {'name': 'Unconditionally Bae', 'bucketlist': 2}
+
+        # unsuccessful creation w/out authentication
+        response = self.client.put(url4, edited_item)
+        self.assertEqual(response.data, message)
+        self.assertEqual(response.status_code, 401)
+
+        # add authentication to client
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+
+        # successful update of a bucketlist item.
+        auth_response = self.client.put(url4, edited_item)
+        self.assertEqual(auth_response.status_code, 200)
+        self.assertEqual(auth_response.data.get('name'), 'Unconditionally Bae')
+
+    def test_bucketlistitem_deletion(self):
+        """Test that a bucketlist item can be deleted."""
+        # unsuccessful deletion w/out authentication
+        response = self.client.delete(url4)
+        self.assertEqual(response.data, message)
+        self.assertEqual(response.status_code, 401)
+
+        # add authentication to client
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+
+        # successfule deletion
+        auth_response = self.client.delete(url4)
+        self.assertEqual(auth_response.status_code, 204)
+        self.assertEqual(Bucketlistitem.objects.count(), 3)

--- a/bucketlist/views.py
+++ b/bucketlist/views.py
@@ -70,7 +70,6 @@ class BucketListView(DefaultsMixin, generics.ListCreateAPIView):
     Allow for retrieval of all bucektlists and bucketlist creation.
     """
 
-    # permission_classes = (permissions.IsAuthenticatedOrReadOnly,)
     queryset = Bucketlist.objects.all()
     serializer_class = BucketlistSerializer
     search_fields = ('name', )
@@ -86,8 +85,6 @@ class BucketlistDetail(DefaultsMixin, generics.RetrieveUpdateDestroyAPIView):
     Allow for retrieval of one bucketlist, its edition and deletion.
     """
 
-    permission_classes = (
-        permissions.IsAuthenticatedOrReadOnly, IsOwnerOrReadOnly,)
     queryset = Bucketlist.objects.all()
     serializer_class = BucketlistSerializer
 

--- a/bucketlist/views.py
+++ b/bucketlist/views.py
@@ -1,8 +1,8 @@
 from django.shortcuts import render, get_object_or_404
-from rest_framework import generics, permissions, status, authentication, filters
+from rest_framework import generics, permissions, status, authentication, \
+    filters
 from rest_framework.response import Response
 from models import Account, Bucketlist, Bucketlistitem
-from permissions import IsOwnerOrReadOnly
 from serializers import AccountSerializer, BucketlistSerializer, \
     BucketlistitemSerializer
 
@@ -41,10 +41,10 @@ class AccountsList(generics.ListAPIView):
         if self.request.method == 'POST':
             return (permissions.AllowAny(), )
 
-        return(permissions.IsAuthenticated(), IsOwnerOrReadOnly(), )
+        return(permissions.IsAuthenticated(), )
 
     def create(self, request):
-        """Override viesets .save method to allow for passwor hashing."""
+        """Override viewsets .save method to allow for password hashing."""
         serializer = self.serializer_class(data=request.data)
 
         if serializer.is_valid():
@@ -60,6 +60,8 @@ class AccountsList(generics.ListAPIView):
 
 
 class AccountsDetail(generics.RetrieveAPIView):
+    """Allow admin access to user details."""
+
     queryset = Account.objects.all()
     serializer_class = AccountSerializer
 
@@ -67,7 +69,7 @@ class AccountsDetail(generics.RetrieveAPIView):
 class BucketListView(DefaultsMixin, generics.ListCreateAPIView):
     """Handle /api/v1/bucketlists/ path.
 
-    Allow for retrieval of all bucektlists and bucketlist creation.
+    Allow for retrieval of all bucketlists and bucketlist creation.
     """
 
     queryset = Bucketlist.objects.all()
@@ -77,6 +79,7 @@ class BucketListView(DefaultsMixin, generics.ListCreateAPIView):
     def perform_create(self, serializer):
         """Associate bucketlist to an account,save data passed in request."""
         serializer.save(creator=self.request.user)
+        # serializer.save(user=self.request.user)
 
 
 class BucketlistDetail(DefaultsMixin, generics.RetrieveUpdateDestroyAPIView):
@@ -104,7 +107,8 @@ class BucketlistItemView(DefaultsMixin, generics.ListCreateAPIView):
         return Bucketlistitem.objects.filter(bucketlist=list_id)
 
 
-class BucketlistItemDetail(DefaultsMixin, generics.RetrieveUpdateDestroyAPIView):
+class BucketlistItemDetail(DefaultsMixin,
+                           generics.RetrieveUpdateDestroyAPIView):
     """Handle /api/v1/bucketlists/<bucketlist_id>/items/<item_id>/path.
 
     Allow for edition and deletion of a bucketlistitem.

--- a/bucketlist/views.py
+++ b/bucketlist/views.py
@@ -79,7 +79,6 @@ class BucketListView(DefaultsMixin, generics.ListCreateAPIView):
     def perform_create(self, serializer):
         """Associate bucketlist to an account,save data passed in request."""
         serializer.save(creator=self.request.user)
-        # serializer.save(user=self.request.user)
 
 
 class BucketlistDetail(DefaultsMixin, generics.RetrieveUpdateDestroyAPIView):
@@ -92,7 +91,7 @@ class BucketlistDetail(DefaultsMixin, generics.RetrieveUpdateDestroyAPIView):
     serializer_class = BucketlistSerializer
 
 
-class BucketlistItemView(DefaultsMixin, generics.ListCreateAPIView):
+class BucketlistItemView(DefaultsMixin, generics.CreateAPIView):
     """Handle /api/v1/bucketlists/<bucketlist_id>/items path.
 
     Allow for bucketlist item creation.

--- a/bucketlist/views.py
+++ b/bucketlist/views.py
@@ -1,14 +1,24 @@
 from django.shortcuts import render, get_object_or_404
-from django.http import HttpResponse
-from django.views.decorators.csrf import csrf_exempt
-from rest_framework import generics, permissions, status
+from rest_framework import generics, permissions, status, authentication
 from rest_framework.response import Response
-from rest_framework.decorators import api_view
-from rest_framework.reverse import reverse
 from models import Account, Bucketlist, Bucketlistitem
 from permissions import IsOwnerOrReadOnly
 from serializers import AccountSerializer, BucketlistSerializer, \
     BucketlistitemSerializer
+
+
+class DefaultsMixin(object):
+    """Default reusable settings for authentication,
+    permissions and filtering.
+    """
+
+    authentication_classes = (
+        authentication.BasicAuthentication,
+        authentication.TokenAuthentication,
+    )
+    permission_classes = (
+        permissions.IsAuthenticated,
+    )
 
 
 class AccountsList(generics.ListAPIView):
@@ -50,13 +60,13 @@ class AccountsDetail(generics.RetrieveAPIView):
     serializer_class = AccountSerializer
 
 
-class BucketListView(generics.ListCreateAPIView):
+class BucketListView(DefaultsMixin, generics.ListCreateAPIView):
     """Handle /api/v1/bucketlists/ path.
 
     Allow for retrieval of all bucektlists and bucketlist creation.
     """
 
-    permission_classes = (permissions.IsAuthenticatedOrReadOnly,)
+    # permission_classes = (permissions.IsAuthenticatedOrReadOnly,)
     queryset = Bucketlist.objects.all()
     serializer_class = BucketlistSerializer
 


### PR DESCRIPTION
#### What does this PR do?

Creates CRUD capabilities for both bucketlist and bucket list items resources.
#### Description of tasks to be completed
- Create API endpoints for bucketlist resources
- Create API endpoints for bucketlist items resources
- Document the API using `Swagger.io`
#### How should this be manually tested?
- The API endpoints may be tested using `Postman` or `HTTPie` CLI client.They may also be simulated on the `Swagger` Documentation interface.
- The actual tests may be run using the command `python manage.py test bucketlist/`
#### Any known issues
- The bucketlist item creation does not pick the bucketlist field it belongs to automatically from the URL as it should.
